### PR TITLE
Update end_port in sample. Update for QosPositionKpi --> QosPostion naming.

### DIFF
--- a/EmptyMatchEngineApp/app/build.gradle
+++ b/EmptyMatchEngineApp/app/build.gradle
@@ -30,13 +30,13 @@ dependencies {
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
 
     // Use local project Matching Engine SDK:
-    implementation project(":matchingengine")
+    //implementation project(":matchingengine")
     implementation "io.grpc:grpc-protobuf-lite:${grpcVersion}"
     // Use maven:
-    //implementation 'com.mobiledgex:matchingengine:1.4.8'
+    implementation 'com.mobiledgex:matchingengine:1.4.9'
     // Dependencies of Matching Engine, if using Maven:
-    //implementation "io.grpc:grpc-okhttp:${grpcVersion}"
-    //implementation "io.grpc:grpc-stub:${grpcVersion}"
+    implementation "io.grpc:grpc-okhttp:${grpcVersion}"
+    implementation "io.grpc:grpc-stub:${grpcVersion}"
 
     // For Google Location Services.
     implementation 'com.google.android.gms:play-services-location:15.0.1'

--- a/EmptyMatchEngineApp/app/src/main/java/com/mobiledgex/emptymatchengineapp/MainActivity.java
+++ b/EmptyMatchEngineApp/app/src/main/java/com/mobiledgex/emptymatchengineapp/MainActivity.java
@@ -340,7 +340,8 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                                 aPort.getProto().getNumber(),
                                 aPort.getInternalPort(),
                                 aPort.getPublicPort(),
-                                aPort.getPathPrefix());
+                                aPort.getPathPrefix(),
+                                aPort.getEndPort());
                         }
 
                         someText += "[Cloudlet App Ports: [" + portListStr + "]\n";

--- a/EmptyMatchEngineApp/matchingengine/build.gradle
+++ b/EmptyMatchEngineApp/matchingengine/build.gradle
@@ -20,7 +20,7 @@ android {
         minSdkVersion 23
         targetSdkVersion 28
         versionCode 1
-        versionName "1.4.8"
+        versionName "1.4.9"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 

--- a/EmptyMatchEngineApp/matchingengine/src/androidTest/java/com/mobiledgex/matchingengine/EngineCallTest.java
+++ b/EmptyMatchEngineApp/matchingengine/src/androidTest/java/com/mobiledgex/matchingengine/EngineCallTest.java
@@ -22,7 +22,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
@@ -1009,7 +1008,7 @@ public class EngineCallTest {
 
             ArrayList<AppClient.QosPosition> kpiRequests = MockUtils.createQosPositionArray(location, direction, totalDistanceKm, increment);
 
-            AppClient.QosPositionKpiRequest request = me.createQoSKPIRequest(kpiRequests);
+            AppClient.QosPositionRequest request = me.createQoSPositionRequest(kpiRequests);
             assertFalse("SessionCookie must not be empty.", request.getSessionCookie().isEmpty());
 
 
@@ -1064,7 +1063,7 @@ public class EngineCallTest {
 
             ArrayList<AppClient.QosPosition> kpiRequests = MockUtils.createQosPositionArray(location, direction, totalDistanceKm, increment);
 
-            AppClient.QosPositionKpiRequest request = me.createQoSKPIRequest(kpiRequests);
+            AppClient.QosPositionRequest request = me.createQoSPositionRequest(kpiRequests);
             assertFalse("SessionCookie must not be empty.", request.getSessionCookie().isEmpty());
 
 

--- a/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngine.java
+++ b/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngine.java
@@ -32,7 +32,7 @@ import distributed_match_engine.AppClient.GetLocationRequest;
 import distributed_match_engine.AppClient.GetLocationReply;
 import distributed_match_engine.AppClient.AppInstListRequest;
 import distributed_match_engine.AppClient.AppInstListReply;
-import distributed_match_engine.AppClient.QosPositionKpiRequest;
+import distributed_match_engine.AppClient.QosPositionRequest;
 import distributed_match_engine.AppClient.QosPositionKpiReply;
 import distributed_match_engine.AppClient.QosPosition;
 
@@ -414,8 +414,8 @@ public class MatchingEngine {
                 .build();
     }
 
-    public QosPositionKpiRequest createQoSKPIRequest(List<QosPosition> requests) {
-        return QosPositionKpiRequest.newBuilder()
+    public QosPositionRequest createQoSPositionRequest(List<QosPosition> requests) {
+        return QosPositionRequest.newBuilder()
                 .setSessionCookie(mSessionCookie)
                 .addAllPositions(requests)
                 .build();
@@ -820,7 +820,7 @@ public class MatchingEngine {
      * @throws InterruptedException
      * @throws ExecutionException
      */
-    public ChannelIterator<QosPositionKpiReply> getQosPositionKpi(QosPositionKpiRequest request,
+    public ChannelIterator<QosPositionKpiReply> getQosPositionKpi(QosPositionRequest request,
                                                                   long timeoutInMilliseconds)
             throws InterruptedException, ExecutionException {
 
@@ -839,7 +839,7 @@ public class MatchingEngine {
      * @throws InterruptedException
      * @throws ExecutionException
      */
-    public Future<ChannelIterator<QosPositionKpiReply>> getQosPositionKpiFuture(QosPositionKpiRequest request,
+    public Future<ChannelIterator<QosPositionKpiReply>> getQosPositionKpiFuture(QosPositionRequest request,
                                                                   long timeoutInMilliseconds)
             throws InterruptedException, ExecutionException {
 
@@ -859,7 +859,7 @@ public class MatchingEngine {
      * @throws InterruptedException
      * @throws ExecutionException
      */
-    public ChannelIterator<QosPositionKpiReply> getQosPositionKpi(QosPositionKpiRequest request,
+    public ChannelIterator<QosPositionKpiReply> getQosPositionKpi(QosPositionRequest request,
                                                                   String host, int port,
                                                                   long timeoutInMilliseconds)
             throws InterruptedException, ExecutionException {
@@ -881,7 +881,7 @@ public class MatchingEngine {
      * @throws InterruptedException
      * @throws ExecutionException
      */
-    public Future<ChannelIterator<QosPositionKpiReply>> getQosPositionKpiFuture(QosPositionKpiRequest request,
+    public Future<ChannelIterator<QosPositionKpiReply>> getQosPositionKpiFuture(QosPositionRequest request,
                                                                                 String host, int port,
                                                                                 long timeoutInMilliseconds)
             throws InterruptedException, ExecutionException {

--- a/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/QosPositionKpi.java
+++ b/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/QosPositionKpi.java
@@ -16,13 +16,13 @@ import io.grpc.StatusRuntimeException;
 
 import distributed_match_engine.MatchEngineApiGrpc;
 import distributed_match_engine.AppClient;
-import distributed_match_engine.AppClient.QosPositionKpiRequest;
+import distributed_match_engine.AppClient.QosPositionRequest;
 import distributed_match_engine.AppClient.QosPositionKpiReply;
 
 public class QosPositionKpi implements Callable {
     public static final String TAG = "QueryQosKpi";
     private MatchingEngine mMatchingEngine;
-    private AppClient.QosPositionKpiRequest mQosPositionKpiRequest;
+    private AppClient.QosPositionRequest mQosPositionKpiRequest;
     private String mHost;
     private int mPort;
     private long mTimeoutInMilliseconds;
@@ -31,7 +31,7 @@ public class QosPositionKpi implements Callable {
         mMatchingEngine = matchingEngine;
     }
 
-    boolean setRequest(QosPositionKpiRequest qosPositionKpiRequest, String host, int port, long timeoutInMilliseconds) throws IllegalArgumentException {
+    boolean setRequest(QosPositionRequest qosPositionKpiRequest, String host, int port, long timeoutInMilliseconds) throws IllegalArgumentException {
         if (!mMatchingEngine.isMatchingEngineLocationAllowed()) {
             Log.e(TAG, "MobiledgeX location is disabled.");
             mQosPositionKpiRequest = null;


### PR DESCRIPTION
Straight forward proto sync.
- end_port added to SDK sample.
- QosPosition naming has changed in the proto. Updated.