### PR TITLE
QoSPosition: Match server behavior. Fix test code.

### DIFF
--- a/EmptyMatchEngineApp/matchingengine/src/androidTest/java/com/mobiledgex/matchingengine/EngineCallTest.java
+++ b/EmptyMatchEngineApp/matchingengine/src/androidTest/java/com/mobiledgex/matchingengine/EngineCallTest.java
@@ -992,23 +992,19 @@ public class EngineCallTest {
         me.setAllowSwitchIfNoSubscriberInfo(true);
 
         enableMockLocation(context,true);
-        Location location = MockUtils.createLocation("getQosPositionKpiTest", 122.3321, 47.6062);
-        MeLocation meLoc = new MeLocation(me);
+        // The test must use a location where data exists on QOS server.
+        Location location = MockUtils.createLocation("getQosPositionKpiTest", 8.5821, 50.11);
 
         try {
-            setMockLocation(context, location);
-            location = meLoc.getBlocking(context, GRPC_TIMEOUT_MS);
-            assertFalse("Mock'ed Location is missing!", location == null);
-
             registerClient(context, me.retrieveNetworkCarrierName(context), me);
 
-            double totalDistanceKm = 200;
+            double totalDistanceKm = 20;
             double increment = 0.1;
             double direction = 45d;
 
             ArrayList<AppClient.QosPosition> kpiRequests = MockUtils.createQosPositionArray(location, direction, totalDistanceKm, increment);
 
-            AppClient.QosPositionRequest request = me.createQoSPositionRequest(kpiRequests);
+            AppClient.QosPositionRequest request = me.createQoSPositionRequest(kpiRequests, 0, null);
             assertFalse("SessionCookie must not be empty.", request.getSessionCookie().isEmpty());
 
 
@@ -1048,23 +1044,19 @@ public class EngineCallTest {
         me.setAllowSwitchIfNoSubscriberInfo(true);
 
         enableMockLocation(context,true);
-        Location location = MockUtils.createLocation("getQosPositionKpiTest", 122.3321, 47.6062);
-        MeLocation meLoc = new MeLocation(me);
+        // The test must use a location where data exists on QOS server.
+        Location location = MockUtils.createLocation("getQosPositionKpiTest", 8.5821, 50.11);
 
         try {
-            setMockLocation(context, location);
-            location = meLoc.getBlocking(context, GRPC_TIMEOUT_MS);
-            assertFalse("Mock'ed Location is missing!", location == null);
-
             registerClient(context, me.retrieveNetworkCarrierName(context), me);
 
-            double totalDistanceKm = 200;
+            double totalDistanceKm = 20;
             double increment = 0.1;
             double direction = 45d;
 
             ArrayList<AppClient.QosPosition> kpiRequests = MockUtils.createQosPositionArray(location, direction, totalDistanceKm, increment);
 
-            AppClient.QosPositionRequest request = me.createQoSPositionRequest(kpiRequests);
+            AppClient.QosPositionRequest request = me.createQoSPositionRequest(kpiRequests, 0, null);
             assertFalse("SessionCookie must not be empty.", request.getSessionCookie().isEmpty());
 
 

--- a/EmptyMatchEngineApp/matchingengine/src/androidTest/java/com/mobiledgex/matchingengine/MockUtils.java
+++ b/EmptyMatchEngineApp/matchingengine/src/androidTest/java/com/mobiledgex/matchingengine/MockUtils.java
@@ -24,6 +24,7 @@ public class MockUtils {
         String networkOperatorName = telManager.getNetworkOperatorName();
         return networkOperatorName;
     }
+
     public static Location createLocation(String provider, double longitude, double latitude) {
         Location loc = new Location(provider);
         loc.setLongitude(longitude);
@@ -36,61 +37,36 @@ public class MockUtils {
         // Create a bunch of locations to get QOS information. Server is to be proxied by the DME server.
         ArrayList<QosPosition> positions = new ArrayList<>();
 
-        Location lastLocation = firstLocation;
+        double kmPerDegreeLong = 111.32; // at Equator
+        double kmPerDegreeLat = 110.57; // at Equator
+        double addLongitude = (Math.cos(direction_degrees/(Math.PI/180)) * increment) / kmPerDegreeLong;
+        double addLatitude = (Math.sin(direction_degrees/(Math.PI/180)) * increment) / kmPerDegreeLat;
+        double i = 0d;
+        double longitude = firstLocation.getLongitude();
+        double latitude = firstLocation.getLatitude();
+
         long id = 1;
-        double traverse;
 
-        // First point:
-        AppClient.QosPosition firstPositionKpi = AppClient.QosPosition.newBuilder()
-                .setPositionid(id)
-                .setGpsLocation(androidToMessageLoc(firstLocation))
-                .build();
-        positions.add(firstPositionKpi);
+        while (i < totalDistanceKm) {
+            longitude += addLongitude;
+            latitude += addLatitude;
+            i += increment;
 
-        // Everything in between:
-        for (traverse = increment; traverse + increment < totalDistanceKm - increment; traverse += increment, id++) {
-            Location next = MockUtils.createLocation(lastLocation.getLongitude(), lastLocation.getLatitude(), direction_degrees, increment);
+            // FIXME: No time is attached to GPS location, as that breaks the server!
+            LocOuterClass.Loc loc = LocOuterClass.Loc.newBuilder()
+                    .setLongitude(longitude)
+                    .setLatitude(latitude)
+                    .build();
+
             QosPosition np = AppClient.QosPosition.newBuilder()
-                    .setPositionid(id)
-                    .setGpsLocation(androidToMessageLoc(next))
+                    .setPositionid(id++)
+                    .setGpsLocation(loc)
                     .build();
-            positions.add(np);
-            lastLocation = next;
-        }
 
-        // Last point, if needed.
-        if (traverse < totalDistanceKm) {
-            Location lastLoc = MockUtils.createLocation(lastLocation.getLongitude(), lastLocation.getLatitude(), direction_degrees, totalDistanceKm);
-            QosPosition lastPosition = QosPosition.newBuilder()
-                    .setPositionid(id)
-                    .setGpsLocation(androidToMessageLoc(lastLoc))
-                    .build();
-            positions.add(lastPosition);
+            positions.add(np);
         }
 
         return positions;
-    }
-
-    /**
-     * Returns a destination long/lat as a Location object, along direction (in degrees), some distance in kilometers away.
-     *
-     * @param longitude_src
-     * @param latitude_src
-     * @param direction_degrees
-     * @param kilometers
-     * @return
-     */
-    public static Location createLocation(double longitude_src, double latitude_src, double direction_degrees, double kilometers) {
-        double direction_radians = direction_degrees * (Math.PI / 180);
-
-        // Provider is static class name:
-        Location newLoc = new Location(MethodHandles.lookup().lookupClass().getName());
-
-        // Not accurate:
-        newLoc.setLongitude(longitude_src + kilometers * Math.cos(direction_radians));
-        newLoc.setLatitude(latitude_src + kilometers * Math.sin(direction_radians));
-
-        return newLoc;
     }
 
     public static LocOuterClass.Loc androidToMessageLoc(Location location) {
@@ -102,6 +78,7 @@ public class MockUtils {
                         .build())
                 .build();
     }
+
     public static AppClient.RegisterClientRequest createMockRegisterClientRequest(String developerName,
                                                                            String appName,
                                                                            MatchingEngine me) {

--- a/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngine.java
+++ b/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngine.java
@@ -35,6 +35,7 @@ import distributed_match_engine.AppClient.AppInstListReply;
 import distributed_match_engine.AppClient.QosPositionRequest;
 import distributed_match_engine.AppClient.QosPositionKpiReply;
 import distributed_match_engine.AppClient.QosPosition;
+import distributed_match_engine.AppClient.BandSelection;
 
 
 import distributed_match_engine.AppClient.DynamicLocGroupRequest;
@@ -50,10 +51,6 @@ import io.grpc.okhttp.OkHttpChannelBuilder;
 import android.content.pm.PackageInfo;
 import android.util.Log;
 
-import javax.net.ssl.KeyManagerFactory;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSocketFactory;
-import javax.net.ssl.TrustManagerFactory;
 
 import static android.content.Context.TELEPHONY_SUBSCRIPTION_SERVICE;
 
@@ -414,11 +411,17 @@ public class MatchingEngine {
                 .build();
     }
 
-    public QosPositionRequest createQoSPositionRequest(List<QosPosition> requests) {
-        return QosPositionRequest.newBuilder()
-                .setSessionCookie(mSessionCookie)
+    public QosPositionRequest createQoSPositionRequest(List<QosPosition> requests, int lte_category, BandSelection band_selection) {
+        QosPositionRequest.Builder builder = QosPositionRequest.newBuilder();
+        builder.setSessionCookie(mSessionCookie)
                 .addAllPositions(requests)
-                .build();
+                .setLteCategory(lte_category);
+
+        if (band_selection != null) {
+            builder.setBandSelection(band_selection);
+        }
+
+        return builder.build();
     }
 
     private Loc androidLocToMeLoc(android.location.Location loc) {


### PR DESCRIPTION
Simplified the long/lat position generator with a cleaner one (not inclusive of last geo position, that's up to the caller now), and put a FIXME into the QoSPositionKpi test code until the server works with the timestamp. Will need to update on other SDKs as well (new qos parameters, and test code).

