### PR TITLE
Throw DmeDnsException if mcc-mnc.dme.mobiledgex.net doesn't resolve.

### DIFF
--- a/EmptyMatchEngineApp/app/build.gradle
+++ b/EmptyMatchEngineApp/app/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     implementation project(":matchingengine")
     implementation "io.grpc:grpc-protobuf-lite:${grpcVersion}"
     // Use maven:
-    //implementation 'com.mobiledgex:matchingengine:1.4.13'
+    //implementation 'com.mobiledgex:matchingengine:1.4.14'
     // Dependencies of Matching Engine, if using Maven:
     //implementation "io.grpc:grpc-okhttp:${grpcVersion}"
     //implementation "io.grpc:grpc-stub:${grpcVersion}"

--- a/EmptyMatchEngineApp/matchingengine/build.gradle
+++ b/EmptyMatchEngineApp/matchingengine/build.gradle
@@ -20,7 +20,7 @@ android {
         minSdkVersion 23
         targetSdkVersion 28
         versionCode 1
-        versionName "1.4.13"
+        versionName "1.4.14"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 

--- a/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/DmeDnsException.java
+++ b/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/DmeDnsException.java
@@ -1,0 +1,11 @@
+package com.mobiledgex.matchingengine;
+
+public class DmeDnsException extends Exception {
+    public DmeDnsException(String msg) {
+        super(msg);
+    }
+
+    public DmeDnsException(String msg, Exception innerException) {
+        super(msg, innerException);
+    }
+}

--- a/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/NetworkManager.java
+++ b/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/NetworkManager.java
@@ -442,7 +442,7 @@ public class NetworkManager extends SubscriptionManager.OnSubscriptionsChangedLi
             Network network = mConnectivityManager.getBoundNetworkForProcess();
             if (network != null) {
                 NetworkCapabilities networkCapabilities = mConnectivityManager.getNetworkCapabilities(network);
-                if (networkCapabilities.hasCapability(NetworkCapabilities.TRANSPORT_CELLULAR) &&
+                if (networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) &&
                         networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)) {
                     hasDataCellCapabilities = true;
                 }


### PR DESCRIPTION
Per discussion, we are just going to force DNS lookup, and see if the generated DME hostname even exists, and throw a single purpose exception before even attempting any DME APIs.

Matches corresponding C# SDK Behavior.