### PR TITLE
Update proto

### DIFF
--- a/EmptyMatchEngineApp/app/build.gradle
+++ b/EmptyMatchEngineApp/app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     defaultConfig {
         applicationId "com.mobiledgex.emptymatchengineapp"
         minSdkVersion 23
@@ -33,7 +33,7 @@ dependencies {
     implementation project(":matchingengine")
     implementation "io.grpc:grpc-protobuf-lite:${grpcVersion}"
     // Use maven:
-    //implementation 'com.mobiledgex:matchingengine:1.4.15'
+    //implementation 'com.mobiledgex:matchingengine:1.4.17'
     // Dependencies of Matching Engine, if using Maven:
     //implementation "io.grpc:grpc-okhttp:${grpcVersion}"
     //implementation "io.grpc:grpc-stub:${grpcVersion}"

--- a/EmptyMatchEngineApp/build.gradle
+++ b/EmptyMatchEngineApp/build.gradle
@@ -15,7 +15,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.2'
+        classpath 'com.android.tools.build:gradle:3.5.3'
         classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.8"
 
         // JFrog Artifactory:

--- a/EmptyMatchEngineApp/matchingengine/build.gradle
+++ b/EmptyMatchEngineApp/matchingengine/build.gradle
@@ -14,13 +14,13 @@ if (!new File(edgeProtoGitRepo).exists() ) {
 }
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     defaultConfig {
         minSdkVersion 23
         targetSdkVersion 28
         versionCode 1
-        versionName "1.4.16"
+        versionName "1.4.17"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
Little changes everywhere. 1.4.17. Version Checks for latest Android 10/Q/29.

retrieveCellularId returns a map of <String, Long> Cellular technology, CellID. One should note CellIdentity is a much larger object than the type normalized radio specific cellular ID (Nid, BaseStationID, Cid), (Int, Long). It is unused, but now available as a util function. There are also 2 potential 5G entries returned, Nr, and Tdcdma (China), if the API level is 29.

appName gets the actual appName, but only in real applications. It fails in test (no Manifest to pull the label from.)

New APIs:
createDefault<API>Request returns a Builder object. This isn't quite clear this is the way going forward, as it's overloaded with the original set. The Default ones don't bother to give options, as the developer can then fill all remaining optionals themselves, then create the class via .build().

On such optional is Tag<String, String>, an array to send/receive <key, values> to/from the server.