### PR TITLE
Fix missing register in registerAndFindCloudlet

### DIFF
--- a/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngine.java
+++ b/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngine.java
@@ -1142,6 +1142,11 @@ public class MatchingEngine {
                 RegisterClientRequest registerClientRequest = createDefaultRegisterClientRequest(context, developerName)
                         .setAuthToken(authToken)
                         .build();
+                RegisterClientReply registerClientReply = me.registerClient(registerClientRequest, me.getNetworkManager().getTimeout());
+
+                if (registerClientReply == null) {
+                    return null;
+                }
 
                 FindCloudletRequest findCloudletRequest =
                         createFindCloudletRequest(context, registerClientRequest.getCarrierName(), location);


### PR DESCRIPTION
host and port-less version of registerAndFindCloudlet doesn't have a test case (which needs them). Fixed missed register call.