### PR TITLE
EDGECLOUD-718: Add NetTest to Android.

### DIFF
--- a/EmptyMatchEngineApp/app/build.gradle
+++ b/EmptyMatchEngineApp/app/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     implementation project(":matchingengine")
     implementation "io.grpc:grpc-protobuf-lite:${grpcVersion}"
     // Use maven:
-    //implementation 'com.mobiledgex:matchingengine:1.4.17'
+    //implementation 'com.mobiledgex:matchingengine:1.4.18'
     // Dependencies of Matching Engine, if using Maven:
     //implementation "io.grpc:grpc-okhttp:${grpcVersion}"
     //implementation "io.grpc:grpc-stub:${grpcVersion}"

--- a/EmptyMatchEngineApp/matchingengine/build.gradle
+++ b/EmptyMatchEngineApp/matchingengine/build.gradle
@@ -20,7 +20,7 @@ android {
         minSdkVersion 23
         targetSdkVersion 28
         versionCode 1
-        versionName "1.4.17"
+        versionName "1.4.18"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 

--- a/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/AppConnectionManager.java
+++ b/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/AppConnectionManager.java
@@ -346,7 +346,7 @@ public class AppConnectionManager {
      * Convenience method. Get the network from NetworkManager, and set the SSLSocket factory
      * for different communication protocols.
      *
-     * @param timeoutMs timeout in milliseconds.
+     * @param timeoutMs connect timeout in milliseconds.
      * @return null can be returned if the network does not exist, if network switching is disabled,
      *         of if a SSL Socket Factory cannot be created.
      */

--- a/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngine.java
+++ b/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngine.java
@@ -335,7 +335,7 @@ public class MatchingEngine {
         return potentialDmeHost;
     }
 
-    NetworkManager getNetworkManager() {
+    public NetworkManager getNetworkManager() {
         return mNetworkManager;
     }
 

--- a/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/NetworkManager.java
+++ b/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/NetworkManager.java
@@ -456,9 +456,10 @@ public class NetworkManager extends SubscriptionManager.OnSubscriptionsChangedLi
     }
 
     /**
-     * Wrapper function to switch, if possible, to a Cellular Data Network connection. This isn't instant. Callback interface.
+     * Wrapper function to get, if possible, to a Cellular Data Network connection. This isn't instant. Callback interface.
+     * Does not bind process.
      */
-    public void switchToCellularInternetNetwork(ConnectivityManager.NetworkCallback networkCallback) {
+    public void requestCellularNetwork(ConnectivityManager.NetworkCallback networkCallback) {
         boolean isCellularData = isCurrentNetworkInternetCellularDataCapable();
         if (isCellularData) {
             return; // Nothing to do, have cellular data
@@ -535,6 +536,7 @@ public class NetworkManager extends SubscriptionManager.OnSubscriptionsChangedLi
                 Log.d(TAG, "requestNetwork onAvailable().");
 
                 mNetwork = network;
+
                 mConnectivityManager.bindProcessToNetwork(network);
                 if (networkCallback == null) {
                     networkCallback.onAvailable(network);

--- a/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/performancemetrics/NetTest.java
+++ b/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/performancemetrics/NetTest.java
@@ -1,0 +1,280 @@
+/**
+ * Copyright 2018-2020 MobiledgeX, Inc. All rights and licenses reserved.
+ * MobiledgeX, Inc. 156 2nd Street #408, San Francisco, CA 94105
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mobiledgex.matchingengine.performancemetrics;
+
+import android.net.Network;
+import android.util.Log;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import com.mobiledgex.matchingengine.MobiledgeXSSLSocketFactory;
+import com.squareup.okhttp.OkHttpClient;
+import com.squareup.okhttp.Request;
+import com.squareup.okhttp.Response;
+
+import javax.net.SocketFactory;
+
+
+public class NetTest
+{
+  public static final String TAG = "NetTest";
+
+  public enum TestType
+  {
+    PING,
+    CONNECT,
+  }
+
+  class Stopwatch {
+    long elapsed;
+    long startts;
+    long endts;
+
+    long reset() {
+      return elapsed = 0;
+    }
+    long start() {
+      startts = System.currentTimeMillis();
+      return startts;
+    }
+
+    long stop() {
+      endts = System.currentTimeMillis();
+      elapsed = endts - startts;
+      return elapsed;
+    }
+
+    long elapsed() {
+      return elapsed;
+    }
+
+  }
+  private Stopwatch stopWatch;
+
+  public boolean runTest;
+
+  private Thread pingThread;
+  public int PingIntervalMS = 5000;
+  public int TestTimeoutMS = 5000;
+  public int ConnectTimeoutMS = 5000;
+
+  public LinkedBlockingQueue<Site> sites;
+
+  public NetTest()
+  {
+    stopWatch = new Stopwatch();
+    sites = new LinkedBlockingQueue<>();
+  }
+
+  private OkHttpClient getHttpClientOnNetwork(Network sourceNetwork) {
+    OkHttpClient httpClient;
+    MobiledgeXSSLSocketFactory mobiledgexSSLSocketFactory = (MobiledgeXSSLSocketFactory)MobiledgeXSSLSocketFactory.getDefault(sourceNetwork);
+
+    // TODO: GetConnection to connect from a particular network interface endpoint
+    httpClient = new OkHttpClient();
+    httpClient.setConnectTimeout(ConnectTimeoutMS, TimeUnit.MILLISECONDS);
+    // Read write Timeouts are on defaults.
+
+    httpClient.setSslSocketFactory(mobiledgexSSLSocketFactory);
+    httpClient.setSocketFactory(sourceNetwork.getSocketFactory());
+    return httpClient;
+  }
+
+  // Create a client and connect/disconnect on a raw TCP server port from a device network Interface.
+  // Not quite ping ICMP.
+  public double ConnectAndDisconnectHostAndPort(Site site)
+  {
+    Network sourceNetwork = site.network;
+    SocketFactory sf = sourceNetwork.getSocketFactory();
+    long elapsed = 0;
+    stopWatch.reset();
+
+    Socket s = null;
+    try {
+      stopWatch.start();
+      s = sf.createSocket(site.host, site.port);
+      elapsed = stopWatch.stop();
+    }
+    catch (IOException ioe) {
+      elapsed = -1;
+    } finally {
+      try {
+        if (s != null) {
+          s.close();
+        }
+      } catch (IOException ioe){
+        // Done.
+      }
+    }
+
+    return elapsed;
+  }
+
+  // Create a client and connect/disconnect from a device network Interface to a particular test
+  // site.
+  public long ConnectAndDisconnect(Site site)
+  {
+    Response result;
+
+    try {
+      stopWatch.reset();
+
+      Request request = new Request.Builder()
+        .url(site.L7Path)
+        .get()
+        .build();
+
+      OkHttpClient httpClient;
+      if (site.network != null) {
+        httpClient = getHttpClientOnNetwork(site.network);
+      } else {
+        httpClient = new OkHttpClient();
+        httpClient.setConnectTimeout(TestTimeoutMS, TimeUnit.MILLISECONDS);
+      }
+
+      // The nature of this app specific GET API call is to expect some kind of
+      // stateless empty body return also 200 OK.
+      stopWatch.start();
+      result = httpClient.newCall(request).execute();
+      long elapsed = stopWatch.stop();
+
+      if (result.isSuccessful()) {
+        return elapsed;
+      }
+
+    } catch (IOException ioe) {
+      ioe.printStackTrace();
+      return -1;
+    }
+    // Error, GET on L7 Path didn't return success.
+    return -1;
+  }
+
+  // Basic ICMP ping. Does not set source network interface, it just pings to see if it is reachable along current default route.
+  public long Ping(Site site)
+  {
+    InetAddress inetAddress = null;
+    try {
+      inetAddress = InetAddress.getByName(site.host);
+    } catch (UnknownHostException uhe) {
+      return -1;
+    }
+
+    long elapsedMS = 0;
+
+    try {
+      stopWatch.reset();
+      stopWatch.start();
+      // Ping:
+      if (inetAddress.isReachable(TestTimeoutMS)) {
+        elapsedMS = stopWatch.stop();
+      }
+      else {
+        elapsedMS = -1;
+      }
+    } catch (IOException ioe) {
+      return -1;
+    }
+
+    return elapsedMS;
+  }
+
+  public boolean doTest(boolean enable)
+  {
+    if (runTest == true && enable == true)
+    {
+      return true;
+    }
+
+    runTest = enable;
+    if (runTest)
+    {
+      pingThread = new Thread() {
+        @Override
+        public void run() {
+          // Exits on runTest == false;
+          RunNetTest();
+        }
+      };
+      pingThread.start();
+    }
+    else
+    {
+      try {
+        pingThread.join(PingIntervalMS);
+      } catch (InterruptedException ie) {
+        // Nothing to do.
+      } finally {
+        pingThread = null;
+      }
+    }
+    return runTest;
+  }
+
+  // Basic utility function to connect and disconnect from any TCP port.
+  public void RunNetTest()
+  {
+    while (runTest)
+    {
+      double elapsed = -1d;
+      for (Site site : sites)
+      {
+        switch (site.testType)
+        {
+          case CONNECT:
+            if (site.L7Path == null) // Simple host and port.
+            {
+              elapsed = ConnectAndDisconnectHostAndPort(site);
+              Log.d(TAG, "site host: " + site.host + ", port" + site.port + ", round-trip: " + elapsed + ", average:  " + site.average + ", stddev: " + site.stddev + ", from net interface id: " + site.network.toString());
+            }
+            else // Use L7 Path.
+            {
+              elapsed = ConnectAndDisconnect(site);
+              Log.d(TAG, "site L7Path: " + site.L7Path + ", round-trip: " + elapsed + ", average:  " + site.average + ", stddev: " + site.stddev + ", from net interface id: " + site.network.toString());
+
+            }
+            break;
+          case PING:
+            {
+              elapsed = Ping(site);
+              Log.d(TAG, "site host: " + site.host + ", port" + site.port + ", round-trip: " + elapsed + ", average:  " + site.average + ", stddev: " + site.stddev);
+            }
+            break;
+        }
+        site.lastPingMs = elapsed;
+        if (elapsed >= 0)
+        {
+          site.addSample(elapsed);
+          site.recalculateStats();
+        }
+      }
+      // Must run inside a thread:
+      try {
+        Thread.sleep(PingIntervalMS);
+      } catch (InterruptedException ie) {
+        // Nothing.
+      }
+    }
+  }
+}
+

--- a/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/performancemetrics/Site.java
+++ b/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/performancemetrics/Site.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2018-2020 MobiledgeX, Inc. All rights and licenses reserved.
+ * MobiledgeX, Inc. 156 2nd Street #408, San Francisco, CA 94105
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mobiledgex.matchingengine.performancemetrics;
+
+import android.net.Network;
+
+public class Site
+{
+  public Network network;
+
+  public String host;
+  public int port;
+  public String L7Path; // This may be load balanced.
+  public double lastPingMs;
+
+  public NetTest.TestType testType;
+
+  int idx;
+  int size;
+  public double[] samples;
+
+  public double average;
+  public double stddev;
+
+  private static final int DEFAULT_NUM_SAMPLES = 5;
+
+  public Site(Network network, String host, int port)
+  {
+    this.network = network;
+    testType = NetTest.TestType.PING;
+    samples = new double[DEFAULT_NUM_SAMPLES];
+  }
+
+  public Site(Network network, NetTest.TestType testType, int numSamples, String L7Path)
+  {
+    this.network = network;
+    this.testType = testType;
+    this.L7Path = L7Path;
+    samples = new double[numSamples];
+  }
+
+  public Site(Network network, NetTest.TestType testType, int numSamples, String host, int port)
+  {
+    this.network = network;
+    this.testType = testType;
+    this.host = host;
+    this.port = port;
+    samples = new double[numSamples];
+  }
+
+  public void addSample(double time)
+  {
+    samples[idx] = time;
+    idx++;
+    if (size < samples.length) size++;
+    idx = idx % samples.length;
+  }
+
+  public void recalculateStats()
+  {
+    double acc = 0d;
+    double vsum = 0d;
+    double d;
+    for (int i = 0; i < size; i++)
+    {
+      acc += samples[i];
+    }
+    average = acc / size;
+    for (int i = 0; i < size; i++)
+    {
+      d = samples[i];
+      vsum += (d - average) * (d - average);
+    }
+    if (size > 1) {
+      // Bias Corrected Sample Variance
+      vsum /= (size - 1);
+    }
+    stddev = Math.sqrt(vsum);
+  }
+}


### PR DESCRIPTION
Android SDK: PerformanceMetrics client side.

Pretty simple usage, find or get a Network from Network manager, and throw it at the background thread:
String l7Url = mMatchingEngine.getAppConnectionManager().createUrl(closestCloudlet, aPort, aPort.getPublicPort());
Site site = new Site(mMatchingEngine.getNetworkManager().getActiveNetwork(), NetTest.TestType.CONNECT, 5, l7Url);
netTest.sites.add(site);

netTest.doTest(true); 

Will swap networks to test (except PING, which doesn't have this concept without swapping the entire process over as it's asking about "reachability").

Right now, it Log.Debugs to console.log, no reason it has to, since the app can get the running sample window data set at any time.