### PR TITLE
EDGECLOUD-2232: Android SDK: do not pass any platform params in FindCloudlet

### DIFF
--- a/EmptyMatchEngineApp/app/src/main/java/com/mobiledgex/emptymatchengineapp/MainActivity.java
+++ b/EmptyMatchEngineApp/app/src/main/java/com/mobiledgex/emptymatchengineapp/MainActivity.java
@@ -364,7 +364,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                     // Find the closest cloudlet for your application to use. (Blocking call, or use findCloudletFuture)
                     // There is also createDefaultFindClouldletRequest() to get a Builder class to fill in optional parameters.
                     AppClient.FindCloudletRequest findCloudletRequest =
-                            mMatchingEngine.createDefaultFindCloudletRequest(ctx, devName, location)
+                            mMatchingEngine.createDefaultFindCloudletRequest(ctx, location)
                             .build();
                     Log.i(TAG, "after create find cloudlet request" + findCloudletRequest);
                     AppClient.FindCloudletReply closestCloudlet = mMatchingEngine.findCloudlet(findCloudletRequest,


### PR DESCRIPTION
Inadvertently (<._<), (>_.>), Android SDK started to send stuff server was not expecting except in Platform app scenario. For the SDK side of things, it should never send them in FindCloudlet, unless specified. The new Builder API based createDefaultFindCloudletRequest helper function will not fill them in. Tests and SDK app updated.

Server will update with a clearer message that ONLY OS level platforms and not apps might have reason to fill them in.

Actually, since we're going to break compatibility soon anyway (orgName), maybe remove it from the fully spec'ed out message constructor as well (will handle later).