### PR TITLE
Temporary fix to test app. Fix uniqueId for next DME server update.

### DIFF
--- a/EmptyMatchEngineApp/app/src/main/java/com/mobiledgex/emptymatchengineapp/MainActivity.java
+++ b/EmptyMatchEngineApp/app/src/main/java/com/mobiledgex/emptymatchengineapp/MainActivity.java
@@ -324,6 +324,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                         // For Demo app, we use the wifi dme server to continue to MobiledgeX.
                         dmeHostAddress = MatchingEngine.wifiOnlyDmeHost;
                     }
+                    dmeHostAddress = "wifi.dme.mobiledgex.net";
 
                     int port = mMatchingEngine.getPort(); // Keep same port.
 
@@ -339,8 +340,9 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                     // like AuthToken or Tag key value pairs.
                     AppClient.RegisterClientRequest registerClientRequest =
                             mMatchingEngine.createDefaultRegisterClientRequest(ctx, orgName)
-                              .setCarrierName(mMatchingEngine.retrieveNetworkCarrierName(ctx))
+                              .setCarrierName("wifi")
                               .setAppName(appName)
+                              .setAppVers(appVers)
                               .build();
                     Log.i(TAG, "registerclient request is " + registerClientRequest);
 
@@ -360,6 +362,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                     // There is also createDefaultFindClouldletRequest() to get a Builder class to fill in optional parameters.
                     AppClient.FindCloudletRequest findCloudletRequest =
                             mMatchingEngine.createDefaultFindCloudletRequest(ctx, location)
+                                .setCarrierName("wifi")
                                 .build();
                     AppClient.FindCloudletReply closestCloudlet = mMatchingEngine.findCloudlet(findCloudletRequest,
                             dmeHostAddress, port, 10000);

--- a/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngine.java
+++ b/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngine.java
@@ -482,8 +482,6 @@ public class MatchingEngine {
 
         // No carrierName is used for DME in register.
         builder.setAuthToken("")
-                .setUniqueId(getUniqueId(context))
-                .setUniqueIdType("applicationInstallId") // FIXME: proto enum type definition needed.
                 .setCellId(0);
                 return builder;
     }


### PR DESCRIPTION
UniqueID should not be set, as it's not being used that way when the DME server finally implements it. Removing before release. At the SDK level, it should not be filled in.

I have not yet removed uniqueID as an API yet from the SDK.