### PR TITLE
Switch FindCloudlet to PROXIMITY mode default. Tests updated to test both. Mirror C# tests to 3. Minor simplification to NetTest no sample sorting.

### DIFF
--- a/EmptyMatchEngineApp/app/build.gradle
+++ b/EmptyMatchEngineApp/app/build.gradle
@@ -7,7 +7,7 @@ android {
         minSdkVersion 24
         targetSdkVersion 28
         versionCode 2
-        versionName "2.0.1"
+        versionName "2.0.2"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/EmptyMatchEngineApp/build.gradle
+++ b/EmptyMatchEngineApp/build.gradle
@@ -15,7 +15,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.2'
+        classpath 'com.android.tools.build:gradle:3.6.3'
         classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.8"
 
         // JFrog Artifactory:

--- a/EmptyMatchEngineApp/matchingengine/build.gradle
+++ b/EmptyMatchEngineApp/matchingengine/build.gradle
@@ -20,7 +20,7 @@ android {
         minSdkVersion 24
         targetSdkVersion 28
         versionCode 4
-        versionName "2.0.1"
+        versionName "2.0.2"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 

--- a/EmptyMatchEngineApp/matchingengine/src/androidTest/java/com/mobiledgex/matchingengine/EngineCallTest.java
+++ b/EmptyMatchEngineApp/matchingengine/src/androidTest/java/com/mobiledgex/matchingengine/EngineCallTest.java
@@ -92,7 +92,7 @@ public class EngineCallTest {
 
     public static String hostOverride = "wifi.dme.mobiledgex.net";
     public static int portOverride = 50051;
-    public static String findCloudletCarrierOverride = ""; // Allow "Any"
+    public static String findCloudletCarrierOverride = "TDG"; // Allow "Any" if using "", but this likely breaks test cases.
 
     public boolean useHostOverride = true;
     public boolean useWifiOnly = true; // This also disables network switching, since the android default is WiFi.
@@ -608,7 +608,8 @@ public class EngineCallTest {
                 .build();
 
             if (useHostOverride) {
-                response = me.findCloudletFuture(findCloudletRequest, hostOverride, portOverride, 10000);
+                response = me.findCloudletFuture(findCloudletRequest, hostOverride, portOverride, GRPC_TIMEOUT_MS,
+                  MatchingEngine.FindCloudletMode.PERFORMANCE);
             } else {
                 response = me.findCloudletFuture(findCloudletRequest, 10000);
             }
@@ -618,7 +619,8 @@ public class EngineCallTest {
             // Second try:
             me.setThreadedPerformanceTest(true);
             if (useHostOverride) {
-                response = me.findCloudletFuture(findCloudletRequest, hostOverride, portOverride, GRPC_TIMEOUT_MS);
+                response = me.findCloudletFuture(findCloudletRequest, hostOverride, portOverride, GRPC_TIMEOUT_MS,
+                  MatchingEngine.FindCloudletMode.PERFORMANCE);
             } else {
                 response = me.findCloudletFuture(findCloudletRequest, GRPC_TIMEOUT_MS);
             }
@@ -1794,9 +1796,9 @@ public class EngineCallTest {
                     .setCarrierName(findCloudletCarrierOverride)
                     .build();
             if (useHostOverride) {
-                findCloudletReply = me.findCloudlet(findCloudletRequest, hostOverride, portOverride, GRPC_TIMEOUT_MS);
+                findCloudletReply = me.findCloudlet(findCloudletRequest, hostOverride, portOverride, GRPC_TIMEOUT_MS, MatchingEngine.FindCloudletMode.PERFORMANCE);
             } else {
-                findCloudletReply = me.findCloudlet(findCloudletRequest, GRPC_TIMEOUT_MS);
+                findCloudletReply = me.findCloudlet(findCloudletRequest, GRPC_TIMEOUT_MS, MatchingEngine.FindCloudletMode.PERFORMANCE);
             }
 
             NetTest netTest = me.getNetTest();
@@ -1843,7 +1845,7 @@ public class EngineCallTest {
             // Some criteria in case a site is pretty close in performance:
             if (bestSite1.host != bestSite2.host) {
                 double diff = bestSite1.average - bestSite2.average;
-                if (diff/bestSite2.average > 0.05d) { // 3%, arbitrary.
+                if (diff/bestSite2.average > 0.15d) { // % arbitrary.
                     assertEquals("The best site, should usually agree in a certain time span if nothing changed.", bestSite1.host, bestSite2.host);
                 }
             }

--- a/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngine.java
+++ b/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngine.java
@@ -924,9 +924,22 @@ public class MatchingEngine {
     public FindCloudletReply findCloudlet(FindCloudletRequest request,
                                           long timeoutInMilliseconds)
             throws DmeDnsException, StatusRuntimeException, InterruptedException, ExecutionException {
-        return findCloudlet(request, generateDmeHostAddress(), getPort(), timeoutInMilliseconds, FindCloudletMode.PERFORMANCE);
-
+        return findCloudlet(request, generateDmeHostAddress(), getPort(), timeoutInMilliseconds, FindCloudletMode.PROXIMITY);
     }
+  /**
+   * findCloudlet finds the closest cloudlet instance as per request.
+   * @param request
+   * @param timeoutInMilliseconds
+   * @return cloudlet URIs
+   * @throws StatusRuntimeException
+   * @throws InterruptedException
+   * @throws ExecutionException
+   */
+  public FindCloudletReply findCloudlet(FindCloudletRequest request,
+                                        long timeoutInMilliseconds, FindCloudletMode mode)
+          throws DmeDnsException, StatusRuntimeException, InterruptedException, ExecutionException {
+      return findCloudlet(request, generateDmeHostAddress(), getPort(), timeoutInMilliseconds, mode);
+  }
 
   /**
    * findCloudlet finds the closest cloudlet instance as per request.
@@ -944,7 +957,7 @@ public class MatchingEngine {
     FindCloudlet findCloudlet = new FindCloudlet(this);
 
     // This also needs some info for MEL.
-    findCloudlet.setRequest(request, host, port, timeoutInMilliseconds, FindCloudletMode.PERFORMANCE);
+    findCloudlet.setRequest(request, host, port, timeoutInMilliseconds, FindCloudletMode.PROXIMITY);
 
     return findCloudlet.call();
   }
@@ -980,7 +993,7 @@ public class MatchingEngine {
     public Future<FindCloudletReply> findCloudletFuture(FindCloudletRequest request,
                                           long timeoutInMilliseconds)
             throws DmeDnsException {
-        return findCloudletFuture(request, generateDmeHostAddress(), getPort(), timeoutInMilliseconds, FindCloudletMode.PERFORMANCE);
+        return findCloudletFuture(request, generateDmeHostAddress(), getPort(), timeoutInMilliseconds, FindCloudletMode.PROXIMITY);
     }
 
   /**
@@ -1009,7 +1022,7 @@ public class MatchingEngine {
                                                         String host, int port,
                                                         long timeoutInMilliseconds) {
       FindCloudlet findCloudlet = new FindCloudlet(this);
-      findCloudlet.setRequest(request, host, port, timeoutInMilliseconds, FindCloudletMode.PERFORMANCE);
+      findCloudlet.setRequest(request, host, port, timeoutInMilliseconds, FindCloudletMode.PROXIMITY);
       return submit(findCloudlet);
     }
 
@@ -1476,7 +1489,7 @@ public class MatchingEngine {
                 FindCloudletRequest findCloudletRequest = findCloudletRequestBuilder.build();
 
                 FindCloudletReply findCloudletReply = me.findCloudlet(findCloudletRequest,
-                        host, port, me.getNetworkManager().getTimeout(), FindCloudletMode.PERFORMANCE);
+                        host, port, me.getNetworkManager().getTimeout(), FindCloudletMode.PROXIMITY);
 
                 return findCloudletReply;
             }

--- a/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/performancemetrics/NetTest.java
+++ b/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/performancemetrics/NetTest.java
@@ -50,7 +50,7 @@ import javax.net.SocketFactory;
 public class NetTest
 {
     public static final String TAG = "NetTest";
-    public int testRounds = 5;
+    public int testRounds = 3;
 
     public enum TestType
     {
@@ -76,7 +76,7 @@ public class NetTest
         public int compare(Site s1, Site s2) {
             // If there's no samples, the other is automatically better.
             if (s1.size == 0 || s2.size == 0) {
-                return s2.size - s1.size > 0 ? 1 : -1;
+                return s1.size > s2.size ? -1 : 1;
             }
 
             if (s1.average < s2.average) {

--- a/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/performancemetrics/Site.java
+++ b/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/performancemetrics/Site.java
@@ -41,7 +41,7 @@ public class Site
 
     public AppClient.Appinstance appInstance;
 
-    public static final int DEFAULT_NUM_SAMPLES = 5;
+    public static final int DEFAULT_NUM_SAMPLES = 3;
 
     public Site(Network network, NetTest.TestType testType, int numSamples, String L7Path)
     {


### PR DESCRIPTION
Does what it says on the tin. Mirrors new 2.0.2 C# MEL development level SDK.