### PR TITLE
Update subscription list local cache result if missing. Fixes tests.

### DIFF
--- a/EmptyMatchEngineApp/matchingengine/build.gradle
+++ b/EmptyMatchEngineApp/matchingengine/build.gradle
@@ -20,7 +20,7 @@ android {
         minSdkVersion 24
         targetSdkVersion 28
         versionCode 4
-        versionName "2.0.9"
+        versionName "2.0.10"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 

--- a/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/NetworkManager.java
+++ b/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/NetworkManager.java
@@ -265,7 +265,7 @@ public class NetworkManager extends SubscriptionManager.OnSubscriptionsChangedLi
     synchronized public List<SubscriptionInfo> getActiveSubscriptionInfoList(boolean clone) throws SecurityException {
 
         if (mActiveSubscriptionInfoList == null) {
-             mActiveSubscriptionInfoList = new ArrayList<>();
+             mActiveSubscriptionInfoList = mSubscriptionManager.getActiveSubscriptionInfoList();
         }
 
         if (clone == false) {


### PR DESCRIPTION
This went into to maven-development as "2.0.9-andy". Test cases don't work with SIM card messages, and not having them work breaks the SDK in a strange way.

This also improves stability, so it's not a bad fix in general.