### PR TITLE
MEL: Fix MccMnc that now returns empty string instead of null. MainActivity: CarrierName can now be null. Remove obsolete MEL message. 

### DIFF
--- a/EmptyMatchEngineApp/app/src/main/java/com/mobiledgex/sdkdemo/MainActivity.java
+++ b/EmptyMatchEngineApp/app/src/main/java/com/mobiledgex/sdkdemo/MainActivity.java
@@ -294,8 +294,9 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                     // If no carrierName, or active Subscription networks, the app should use the public cloud instead.
                     List<SubscriptionInfo> subList = mMatchingEngine.getActiveSubscriptionInfoList();
                     if (subList != null && subList.size() > 0) {
-                        for(SubscriptionInfo info: subList) {
-                            if (info.getCarrierName().equals("Android")) {
+                        for (SubscriptionInfo info: subList) {
+                            CharSequence carrierName = info.getCarrierName();
+                            if (carrierName != null && carrierName.equals("Android")) {
                                 someText += "Emulator Active Subscription Network: " + info.toString() + "\n";
                             } else {
                                 someText += "Active Subscription network: " + info.toString() + "\n";
@@ -507,6 +508,15 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                     MelMessaging.getCookie("MobiledgeX SDK Demo"); // Import MEL messaging.
                     Log.e(TAG, e.getMessage());
                     Log.e(TAG, Log.getStackTraceString(e));
+                } catch (Exception e) {
+                  someText += "Exception failure: " + e.getMessage();
+                  ctx.runOnUiThread(new Runnable() {
+                    @Override
+                    public void run() {
+                      TextView tv = findViewById(R.id.mobiledgex_verified_location_content);
+                      tv.setText(someText);
+                    }
+                  });
                 }
             }
         });

--- a/EmptyMatchEngineApp/matchingengine/build.gradle
+++ b/EmptyMatchEngineApp/matchingengine/build.gradle
@@ -20,7 +20,7 @@ android {
         minSdkVersion 24
         targetSdkVersion 28
         versionCode 4
-        versionName "2.0.10"
+        versionName "2.0.11"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 

--- a/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngine.java
+++ b/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngine.java
@@ -398,7 +398,7 @@ public class MatchingEngine {
         }
 
         String mccmnc = telManager.getNetworkOperator();
-        if (mccmnc == null) {
+        if (mccmnc == null || mccmnc.isEmpty()) {
             Log.e(TAG, "No mcc-mnc string available.");
             return wifiOnlyDmeHost; // fallback to wifi.
         }

--- a/EmptyMatchEngineApp/mel/build.gradle
+++ b/EmptyMatchEngineApp/mel/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion 24
         targetSdkVersion 29
         versionCode 1
-        versionName "1.0.9"
+        versionName "1.0.10"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-rules.pro'

--- a/EmptyMatchEngineApp/mel/src/main/java/com/mobiledgex/mel/MelMessaging.java
+++ b/EmptyMatchEngineApp/mel/src/main/java/com/mobiledgex/mel/MelMessaging.java
@@ -20,7 +20,6 @@ public class MelMessaging {
 
     // Action Filters to declare on the Service side (TBD):
     public static final String ACTION_SET_TOKEN = "com.mobiledgex.intent.action.SET_TOKEN"; // SEC name confirmed.
-    public static final String ACTION_SEND_COOKIES = "com.mobiledgex.intent.action.SEND_COOKIES"; // SEC name confirmed.
 
     // Parcel Keys TODO: Rename keys.
     public static final String EXTRA_PARAM_TOKEN = "com.mobiledgex.intent.extra.PARAM_TOKEN"; // SEC name confirmed.
@@ -79,12 +78,6 @@ public class MelMessaging {
         if (mMelStateReceiver == null) {
             mMelStateReceiver = new MelStateReceiver();
         }
-        // Register Receivers
-        IntentFilter filter;
-
-        filter = new IntentFilter(ACTION_SEND_COOKIES);
-        filter.addCategory(Intent.CATEGORY_DEFAULT);
-        context.registerReceiver(mMelStateReceiver, filter);
     }
 
     static public void unregisterReceivers(Context context) {
@@ -93,9 +86,7 @@ public class MelMessaging {
         }
     }
 
-    // FIXME: Set a dummy token if not already set on system.
-    // Intents fired need the caller to return control to activity to start processing.
-    // Poll for completion.
+    // Early init for potential intent receivers.
     public static void sendForMelStatus(final Context context, String appName) {
         if (mMelStateReceiver == null && listenForAppStatus == true) {
             registerReceivers(context);
@@ -104,9 +95,6 @@ public class MelMessaging {
         }
 
         getUid();
-
-        // Does this check if our app is registered on platform?
-        sendGetAppRegStatus(context, appName);
     }
 
     // For use in PlatformFindCloudlet.
@@ -125,21 +113,6 @@ public class MelMessaging {
             Log.e(TAG, "sendSetToken cannot send." + ise.getMessage());
         }
         return "";
-    }
-
-    // FIXME: Why get and receive this? Current known usage is to populate a property to read reg app status.
-    public static void sendGetAppRegStatus(Context context, String appName) {
-        Intent intent = new Intent(ACTION_SEND_COOKIES);
-        intent.setClassName(pkg, cls);
-        intent.setAction(ACTION_SEND_COOKIES);
-        intent.putExtra(EXTRA_PARAM_APP_NAME_KEY, appName);
-
-        try {
-            Log.i(TAG, "sendGetAppRegStatus triggered.");
-            context.sendBroadcast(intent);
-        } catch (IllegalStateException ise) {
-            Log.i(TAG, "sendGetAppRegStatus cannot send." + ise.getMessage());
-        }
     }
 }
 

--- a/EmptyMatchEngineApp/mel/src/main/java/com/mobiledgex/mel/MelStateReceiver.java
+++ b/EmptyMatchEngineApp/mel/src/main/java/com/mobiledgex/mel/MelStateReceiver.java
@@ -10,9 +10,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.lang.reflect.Method;
 
-import static com.mobiledgex.mel.MelMessaging.ACTION_SEND_COOKIES;
 import static com.mobiledgex.mel.MelMessaging.ACTION_SET_TOKEN;
-import static com.mobiledgex.mel.MelMessaging.EXTRA_PARAM_COOKIE;
 import static com.mobiledgex.mel.MelMessaging.EXTRA_PARAM_TOKEN;
 
 public class MelStateReceiver extends BroadcastReceiver {
@@ -36,11 +34,6 @@ public class MelStateReceiver extends BroadcastReceiver {
             case ACTION_SET_TOKEN: {
                 client_token = intent.getStringExtra(EXTRA_PARAM_TOKEN);
                 Log.d(TAG, "currentToken: " + client_token);
-                break;
-            }
-            case ACTION_SEND_COOKIES: {
-                appCookie = intent.getStringExtra(EXTRA_PARAM_COOKIE);
-                Log.d(TAG, "Got Token: " + appCookie);
                 break;
             }
         }


### PR DESCRIPTION
- API 29/S20: MCCMNC now returns "" instead of null. Now handled. (Airplane mode + wifi enabled, or just Wifi enabled).
- CarrierName in SubscriptionList: Can now be null. Now handled (MainActivity, not SDK code)
- MelMessaging no longer uses obsolete SEND_COOKIES (former SET_TOKEN). System side doesn't have it anymore.
- This also affects Unity SDK + Android, but C# SDK already checks it, since it is developer supplied.