### PR TITLE
Bump version to 2.1.0

### DIFF
--- a/EmptyMatchEngineApp/app/build.gradle
+++ b/EmptyMatchEngineApp/app/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     implementation project(":mel")
     implementation "io.grpc:grpc-protobuf-lite:${grpcVersion}"
     // Use maven:
-    //implementation 'com.mobiledgex:matchingengine:2.0.14'
+    //implementation 'com.mobiledgex:matchingengine:2.1.0'
     //implementation 'com.mobiledgex:mel:1.0.11'
     // Dependencies of Matching Engine, if using Maven:
     implementation "io.grpc:grpc-okhttp:${grpcVersion}"

--- a/EmptyMatchEngineApp/matchingengine/build.gradle
+++ b/EmptyMatchEngineApp/matchingengine/build.gradle
@@ -20,7 +20,7 @@ android {
         minSdkVersion 24
         targetSdkVersion 28
         versionCode 4
-        versionName "2.0.14"
+        versionName "2.1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
Andy, your name is one this one. I'll manually edit to push to maven-releases, since the default points to maven-development, which I think is a good default as it's all manual for now.

local.properties would be better for a future auto build script/auto test script/cicd. We just don't have one yet.