### PR TITLE
Use Android_ID for MEL not enabled, or has no UID.

### DIFF
--- a/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngine.java
+++ b/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngine.java
@@ -368,7 +368,8 @@ public class MatchingEngine {
     }
 
     String getUniqueId(Context context) {
-        String uuid = Secure.getString(context.getContentResolver(),
+        String uuid;
+        uuid = Secure.getString(context.getContentResolver(),
                 Secure.ANDROID_ID);
         Log.d(TAG, "uuid is " + uuid);
         return uuid;


### PR DESCRIPTION
3b:

Based on new info:

If and only if Manufacturer == Samsung, and there's no UID (hence, either not activated, or doesn't have MEL), go off and send, if available, Android_ID.