### PR TITLE
EDGECLOUD-3240: Remove unused package.

### DIFF
--- a/EmptyMatchEngineApp/matchingengine/build.gradle
+++ b/EmptyMatchEngineApp/matchingengine/build.gradle
@@ -101,7 +101,6 @@ dependencies {
 
     // For Google Services
     implementation 'com.google.android.gms:play-services-location:17.0.0'
-    implementation 'com.google.android.gms:play-services-ads-identifier:17.0.0'
 
     // For JWT validation
     implementation 'com.auth0.android:jwtdecode:2.0.0'

--- a/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngine.java
+++ b/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngine.java
@@ -28,11 +28,6 @@ import android.net.wifi.WifiManager;
 import android.os.Build;
 import android.provider.Settings;
 
-import com.google.android.gms.ads.identifier.AdvertisingIdClient;
-
-import com.google.android.gms.common.GooglePlayServicesNotAvailableException;
-import com.google.android.gms.common.GooglePlayServicesRepairableException;
-
 import androidx.annotation.RequiresApi;
 
 import android.telephony.CarrierConfigManager;


### PR DESCRIPTION
Removing unused imports. already pushed to rc5 (flush gradle cache!) Necessary, as this may conflict with App's desire to use something both older or newer (< v17, or androidX 1.0.0 alphas).