### PR TITLE
Fix App build. protobuf-lite conflict with protobuf.

### DIFF
--- a/EmptyMatchEngineApp/app/build.gradle
+++ b/EmptyMatchEngineApp/app/build.gradle
@@ -31,13 +31,16 @@ dependencies {
     // Use local project Matching Engine SDK:
     implementation project(":matchingengine")
     implementation project(":mel")
-    implementation "io.grpc:grpc-protobuf-lite:${grpcVersion}"
+
     // Use maven:
     //implementation 'com.mobiledgex:matchingengine:2.3.0'
     //implementation 'com.mobiledgex:mel:1.0.11'
     // Dependencies of Matching Engine, if using Maven:
-    implementation "io.grpc:grpc-okhttp:${grpcVersion}"
     //implementation "io.grpc:grpc-stub:${grpcVersion}"
+
+    // Common dependencies between maven and local project:
+    implementation "io.grpc:grpc-okhttp:${grpcVersion}" // If using embedded OKHttp from GPRC
+    implementation "io.grpc:grpc-protobuf-lite:${grpcVersion}"
 
     // For Google Location Services.
     implementation 'com.google.android.gms:play-services-location:16.0.0'

--- a/EmptyMatchEngineApp/matchingengine/build.gradle
+++ b/EmptyMatchEngineApp/matchingengine/build.gradle
@@ -58,10 +58,8 @@ protobuf {
         artifact = 'com.google.protobuf:protoc:3.12.0'
     }
     plugins {
-        plugins {
-            grpc {
-                artifact = "io.grpc:protoc-gen-grpc-java:${grpcVersion}"
-            }
+        grpc {
+            artifact = "io.grpc:protoc-gen-grpc-java:${grpcVersion}"
         }
     }
     generateProtoTasks {
@@ -94,12 +92,10 @@ dependencies {
     androidTestImplementation 'com.google.code.gson:gson:2.8.6'
     androidTestImplementation "com.squareup.okio:okio:1.13.0"
 
-    implementation "io.grpc:grpc-okhttp:${grpcVersion}"
-    implementation "io.grpc:grpc-protobuf-lite:${grpcVersion}"
     implementation "io.grpc:grpc-stub:${grpcVersion}"
+    implementation "io.grpc:grpc-protobuf-lite:${grpcVersion}"
+    implementation "io.grpc:grpc-okhttp:${grpcVersion}"
 
-    // FIXME: https://github.com/google/protobuf-gradle-plugin/issues/431 get a copy of descriptor.proto.
-    protobuf 'com.google.protobuf:protobuf-java:3.13.0'
     implementation 'org.apache.tomcat:annotations-api:6.0.53'
 
     // For Google Services


### PR DESCRIPTION
protobuf-javalite library removed descriptor.proto library source. adding protobuf-java proto sources produced so many conflicts in the app, that it wasn't a proper fix without pro guard surgery to remove most of it. protobuf() (unlike implementation) is not supposed to actually export the objects, but since it does, it's duplicate classes everywhere.

It is now individually, in edge-proto along with http and annotation.proto until someone fixes the library dependencies.