### PR TITLE
EDGECLOUD-2857: Print GPRC API Exception message to Error, and rethrow.

### DIFF
--- a/EmptyMatchEngineApp/app/src/main/java/com/mobiledgex/sdkdemo/MainActivity.java
+++ b/EmptyMatchEngineApp/app/src/main/java/com/mobiledgex/sdkdemo/MainActivity.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2020 MobiledgeX, Inc. All rights and licenses reserved.
+ * Copyright 2018-2021 MobiledgeX, Inc. All rights and licenses reserved.
  * MobiledgeX, Inc. 156 2nd Street #408, San Francisco, CA 94105
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -333,16 +333,16 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                     }
                     dmeHostAddress = "us-mexdemo." + MatchingEngine.baseDmeHost;
                     //mMatchingEngine.setUseWifiOnly(true);
-                    dmeHostAddress = mMatchingEngine.generateDmeHostAddress();
+                    //dmeHostAddress = mMatchingEngine.generateDmeHostAddress();
 
                     int port = mMatchingEngine.getPort(); // Keep same port.
 
-                    String orgName = "MobiledgeX"; // Always supplied by application, and in the MobiledgeX web admin console.
+                    String orgName = "MobiledgeX-Samples"; // Always supplied by application, and in the MobiledgeX web admin console.
                     // For illustration, the matching engine can be used to programatically get the name of your application details
                     // so it can go to the correct appInst version. That AppInst on the server side must match the application
                     // version or else it won't be found and cannot be used.
-                    String appName = "MobiledgeX SDK Demo"; // AppName must be added to the MobiledgeX web admin console.
-                    String appVers = "2.0"; // override the version of that known registered app.
+                    String appName = "ComputerVision"; // AppName must be added to the MobiledgeX web admin console.
+                    String appVers = "2.2"; // override the version of that known registered app.
 
                     // Use createDefaultRegisterClientRequest() to get a Builder class to fill in optional parameters
                     // like AuthToken or Tag key value pairs.
@@ -504,7 +504,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
 
                     // Set network back to last default one, if desired:
                     mMatchingEngine.getNetworkManager().resetNetworkToDefault();
-                } catch (/*DmeDnsException |*/ ExecutionException | StatusRuntimeException e) {
+                } catch ( /*DmeDnsException |*/  ExecutionException | StatusRuntimeException e) {
                     Log.e(TAG, e.getMessage());
                     Log.e(TAG, Log.getStackTraceString(e));
                     if (e.getCause() instanceof NetworkRequestTimeoutException) {

--- a/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/AddUserToGroup.java
+++ b/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/AddUserToGroup.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2020 MobiledgeX, Inc. All rights and licenses reserved.
+ * Copyright 2018-2021 MobiledgeX, Inc. All rights and licenses reserved.
  * MobiledgeX, Inc. 156 2nd Street #408, San Francisco, CA 94105
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -86,6 +86,9 @@ class AddUserToGroup implements Callable {
 
             reply = stub.withDeadlineAfter(mTimeoutInMilliseconds, TimeUnit.MILLISECONDS)
                     .addUserToGroup(mRequest);
+        } catch (Exception e) {
+            Log.e(TAG, "Exception during AddUserToGroup: " + e.getMessage());
+            throw e;
         } finally {
             if (channel != null) {
                 channel.shutdown();

--- a/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/AppOfficialFqdn.java
+++ b/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/AppOfficialFqdn.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2020 MobiledgeX, Inc. All rights and licenses reserved.
+ * Copyright 2018-2021 MobiledgeX, Inc. All rights and licenses reserved.
  * MobiledgeX, Inc. 156 2nd Street #408, San Francisco, CA 94105
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -91,6 +91,9 @@ class AppOfficialFqdn implements Callable {
 
       reply = stub.withDeadlineAfter(mTimeoutInMilliseconds, TimeUnit.MILLISECONDS)
         .getAppOfficialFqdn(mRequest);
+    } catch (Exception e) {
+        Log.e(TAG, "Exception during AppOfficialFqdn: " + e.getMessage());
+        throw e;
     } finally {
       if (channel != null) {
         channel.shutdown();

--- a/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/FindCloudlet.java
+++ b/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/FindCloudlet.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2020 MobiledgeX, Inc. All rights and licenses reserved.
+ * Copyright 2018-2021 MobiledgeX, Inc. All rights and licenses reserved.
  * MobiledgeX, Inc. 156 2nd Street #408, San Francisco, CA 94105
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -241,6 +241,9 @@ public class FindCloudlet implements Callable {
                 .build();
             fcreply = bestFindCloudletReply;
 
+        } catch (Exception e) {
+            Log.e(TAG, "Exception during FindCloudlet: " + e.getMessage());
+            throw e;
         } finally {
             if (channel != null) {
                 channel.shutdown();
@@ -310,6 +313,9 @@ public class FindCloudlet implements Callable {
                 reply.getClientToken(),
                 mMatchingEngine.getLastRegisterClientRequest().getAppName());
 
+        } catch (Exception e) {
+            Log.e(TAG, "Exception during FindCloudlet: " + e.getMessage());
+            throw e;
         } finally {
             if (channel != null) {
                 channel.shutdown();
@@ -317,9 +323,7 @@ public class FindCloudlet implements Callable {
             }
         }
 
-
-
-      return fcReply;
+        return fcReply;
     }
 
     @Override
@@ -336,8 +340,6 @@ public class FindCloudlet implements Callable {
         // Is Wifi Enabled, and has IP?
         Stopwatch stopwatch = Stopwatch.createStarted();
         long ip = mMatchingEngine.getWifiIp(mMatchingEngine.mContext);
-
-
 
         if (MelMessaging.isMelEnabled() && ip == 0) { // MEL is Cellular only. No WiFi.
             // MEL is enabled, alternate findCloudlet behavior:

--- a/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/GetAppInstList.java
+++ b/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/GetAppInstList.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2020 MobiledgeX, Inc. All rights and licenses reserved.
+ * Copyright 2018-2021 MobiledgeX, Inc. All rights and licenses reserved.
  * MobiledgeX, Inc. 156 2nd Street #408, San Francisco, CA 94105
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -114,6 +114,9 @@ public class GetAppInstList implements Callable {
 
             reply = stub.withDeadlineAfter(mTimeoutInMilliseconds, TimeUnit.MILLISECONDS)
                     .getAppInstList(mRequest);
+        } catch (Exception e) {
+            Log.e(TAG, "Exception during GetAppInstList: " + e.getMessage());
+            throw e;
         } finally {
             if (channel != null) {
                 channel.shutdown();

--- a/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/RegisterClient.java
+++ b/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/RegisterClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2020 MobiledgeX, Inc. All rights and licenses reserved.
+ * Copyright 2018-2021 MobiledgeX, Inc. All rights and licenses reserved.
  * MobiledgeX, Inc. 156 2nd Street #408, San Francisco, CA 94105
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -128,6 +128,9 @@ public class RegisterClient implements Callable {
 
             reply = stub.withDeadlineAfter(mTimeoutInMilliseconds, TimeUnit.MILLISECONDS)
                     .registerClient(mRequest);
+        } catch (Exception e) {
+            Log.e(TAG, "Exception during RegisterClient: " + e.getMessage());
+            throw e;
         } finally {
             if (channel != null) {
                 channel.shutdown();

--- a/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/VerifyLocation.java
+++ b/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/VerifyLocation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2020 MobiledgeX, Inc. All rights and licenses reserved.
+ * Copyright 2018-2021 MobiledgeX, Inc. All rights and licenses reserved.
  * MobiledgeX, Inc. 156 2nd Street #408, San Francisco, CA 94105
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -148,6 +148,9 @@ public class VerifyLocation implements Callable {
 
             reply = stub.withDeadlineAfter(mTimeoutInMilliseconds, TimeUnit.MILLISECONDS)
                     .verifyLocation(grpcRequest);
+        } catch (Exception e) {
+            Log.e(TAG, "Exception during VerifyLocation: " + e.getMessage());
+            throw e;
         } finally {
             if (channel != null) {
                 channel.shutdown();


### PR DESCRIPTION
Catch, Log.e, rethrow e.

Print exception, not return nulls. This does mean nobody should need to check for nulls anymore in the App, but it's usually a good idea anyway. The app's wrapped exception handler will need to recover the app state, possibly in a another context. This matches the newer C# and Swift usage, as per bug.

Yes, there's an extra Log.e to discuss (for early development purposes, not so much later mature code), although the app can get and print the stack if they want still.