### PR TITLE
EDGECLOUD-4319: Print to ERROR if GRPC channel is set to use insecure channel.

### DIFF
--- a/EmptyMatchEngineApp/app/build.gradle
+++ b/EmptyMatchEngineApp/app/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     implementation project(":mel")
 
     // Use maven:
-    //implementation 'com.mobiledgex:matchingengine:2.4.0'
+    //implementation 'com.mobiledgex:matchingengine:2.4.2'
     //implementation 'com.mobiledgex:mel:1.0.11'
     // Dependencies of Matching Engine, if using Maven:
     //implementation "io.grpc:grpc-stub:${grpcVersion}"

--- a/EmptyMatchEngineApp/matchingengine/build.gradle
+++ b/EmptyMatchEngineApp/matchingengine/build.gradle
@@ -22,7 +22,7 @@ android {
         minSdkVersion 24
         targetSdkVersion 28
         versionCode 7
-        versionName "2.4.0"
+        versionName "2.4.2"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 

--- a/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngine.java
+++ b/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngine.java
@@ -1807,6 +1807,7 @@ public class MatchingEngine {
                     .sslSocketFactory(mobiledgexSSLSocketFactory)
                     .build();
         } else {
+            Log.e(TAG, "MatchingEngine Communications Channel is set to NOT SECURE. Non-production use only!");
             return ManagedChannelBuilder
                     .forAddress(host, port)
                     .usePlaintext()


### PR DESCRIPTION
It's a more chatty error message. Chatty good!