### PR TITLE
Update EdgeEvents tests, misc fixes.

### DIFF
--- a/EmptyMatchEngineApp/app/build.gradle
+++ b/EmptyMatchEngineApp/app/build.gradle
@@ -35,10 +35,10 @@ dependencies {
     implementation 'com.google.guava:guava:29.0-android'
 
     // Use maven:
-    //implementation 'com.mobiledgex:matchingengine:2.5.0'
+    //implementation 'com.mobiledgex:matchingengine:2.6.0-2'
     //implementation 'com.mobiledgex:mel:1.0.11'
     // Dependencies of Matching Engine, if using Maven:
-    //implementation "io.grpc:grpc-stub:${grpcVersion}"
+    implementation "io.grpc:grpc-stub:${grpcVersion}"
 
     // Common dependencies between maven and local project:
     implementation "io.grpc:grpc-okhttp:${grpcVersion}" // If using embedded OKHttp from GPRC

--- a/EmptyMatchEngineApp/app/src/main/java/com/mobiledgex/sdkdemo/MainActivity.java
+++ b/EmptyMatchEngineApp/app/src/main/java/com/mobiledgex/sdkdemo/MainActivity.java
@@ -49,6 +49,7 @@ import com.mobiledgex.matchingengine.DmeDnsException;
 import com.mobiledgex.matchingengine.EdgeEventsConnection;
 import com.mobiledgex.matchingengine.MatchingEngine;
 import com.mobiledgex.matchingengine.NetworkRequestTimeoutException;
+import com.mobiledgex.matchingengine.edgeeventsconfig.ClientEventsConfig;
 import com.mobiledgex.matchingengine.edgeeventsconfig.EdgeEventsConfig;
 import com.mobiledgex.matchingengine.edgeeventsconfig.FindCloudletEvent;
 import com.mobiledgex.matchingengine.performancemetrics.NetTest;
@@ -706,11 +707,10 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                                 .build();
                     Log.i(TAG, "verifyRequest is " + verifyRequest);
 
-                    //bus.post()
                     // Skip the bus. Just send it:
                     location.setLatitude(40.7127837); // New York.
                     location.setLongitude(-74.0059413);
-                    //mMatchingEngine.getEdgeEventsConnection().postLocationUpdate(location);
+                    mMatchingEngine.getEdgeEventsConnection().postLocationUpdate(location);
 
                     if (false /*verifyRequest != null*/) {
                         // Location Verification (Blocking, or use verifyLocationFuture):

--- a/EmptyMatchEngineApp/matchingengine/build.gradle
+++ b/EmptyMatchEngineApp/matchingengine/build.gradle
@@ -22,7 +22,7 @@ android {
         minSdkVersion 24
         targetSdkVersion 28
         versionCode 7
-        versionName "2.6.0"
+        versionName "2.6.0-2"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/EdgeEventsConnection.java
+++ b/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/EdgeEventsConnection.java
@@ -812,6 +812,7 @@ public class EdgeEventsConnection {
         }
 
         if (port <= 0) {
+            postErrorToEventHandler(EdgeEventsError.portDoesNotExist);
             return false;
         }
 


### PR DESCRIPTION
Edge Events test needed to look at the server responses, not the engine responses.

Minor tweak to post error event of supplied test port being zero for some reason.