### PR TITLE
Thread fixes due to random EdgeEvent timer tasks not seeing shutdown and open notify. Wrong thread monitor.

### DIFF
--- a/EmptyMatchEngineApp/app/src/main/java/com/mobiledgex/sdkdemo/MainActivity.java
+++ b/EmptyMatchEngineApp/app/src/main/java/com/mobiledgex/sdkdemo/MainActivity.java
@@ -551,8 +551,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                         netTest.addSite(site);
                         netTest.testSites(netTest.TestTimeoutMS); // Test the one we just added.
 
-                        if (mMatchingEngine.getEdgeEventsConnection() == null) {
-                            // Might not exist, or is not configured to start.
+                        if (mMatchingEngine.isShutdown()) {
                             return;
                         }
 

--- a/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngine.java
+++ b/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngine.java
@@ -193,6 +193,7 @@ public class MatchingEngine {
         mNetTest = new NetTest();
         mEnableEdgeEvents = true;
         mEdgeEventBus = new AsyncEventBus(threadpool);
+        mEdgeEventsConnection = new EdgeEventsConnection(this, null);
 
         if (MelMessaging.isMelEnabled()) {
             // Updates and sends for MEL status:
@@ -215,6 +216,7 @@ public class MatchingEngine {
         mNetTest = new NetTest();
         mEnableEdgeEvents = true;
         mEdgeEventBus = new AsyncEventBus(executorService);
+        mEdgeEventsConnection = new EdgeEventsConnection(this, null);
 
         if (MelMessaging.isMelEnabled()) {
             // Updates and sends for MEL status:
@@ -330,8 +332,16 @@ public class MatchingEngine {
             Log.e(TAG, "EdgeEventsConfig should not be null! See createDefaultEdgeEventsConfig(). startEdgeEvents() will create a minimal un-customized basic config for initial use.");
             edgeEventsConfig = createDefaultEdgeEventsConfig();
         }
+        if (isShutdown()) {
+            return false;
+        }
         mAppInitiatedRunEdgeEvents = true;
-        return startEdgeEvents(null, 0, null, edgeEventsConfig);
+        try {
+            return startEdgeEvents(null, 0, null, edgeEventsConfig);
+        } catch (DmeDnsException dde) {
+            Log.e(TAG, "Failed to start DME EdgeEvents Connection, could not create DME hostname. The configuration given will be used for next attempt.");
+            return false;
+        }
     }
 
     // Do not use in production. DME will likely change, this sets the initial DME connection.
@@ -342,7 +352,11 @@ public class MatchingEngine {
         return CompletableFuture.supplyAsync(new Supplier<Boolean>() {
             @Override
             public Boolean get() {
-                return startEdgeEvents(dmeHost, dmePort, network, edgeEventsConfig);
+                try {
+                    return startEdgeEvents(dmeHost, dmePort, network, edgeEventsConfig);
+                } catch (DmeDnsException dde) {
+                    throw new CompletionException(dde);
+                }
             }
         });
     }
@@ -352,7 +366,7 @@ public class MatchingEngine {
     synchronized public boolean startEdgeEvents(String dmeHost,
                                                 int dmePort,
                                                 Network network,
-                                                EdgeEventsConfig edgeEventsConfig) {
+                                                EdgeEventsConfig edgeEventsConfig) throws DmeDnsException {
         warnIfUIThread();
         if (!mEnableEdgeEvents) {
             Log.w(TAG, "EdgeEvents has been disabled.");
@@ -370,25 +384,35 @@ public class MatchingEngine {
             return false; // NOT started.
         }
 
-        // Start, if not already, the edgeEvents connection. It also starts any deferred events.
-        // Reconnecting via FindCloudlet, will also call startEdgeEvents.
-        if (mEdgeEventsConnection == null || mEdgeEventsConnection.isShutdown()) {
+        if ((dmeHost == null || dmeHost.isEmpty()) || dmePort <= 0) {
             try {
-                mEdgeEventsConnection = getEdgeEventsConnection(dmeHost, dmePort, network, mEdgeEventsConfig);
+                dmeHost = generateDmeHostAddress();
+                dmePort = port;
             } catch (DmeDnsException dde) {
-                Log.e(TAG, "Exception trying to connect to DME host. Message: " + dde.getLocalizedMessage());
-                throw new CompletionException(dde);
+                Log.e(TAG, "Cannot create EdgeEventsConnection. If needed, use WifiOnly setting.");
+                throw dde;
             }
-            if (mAppInitiatedRunEdgeEvents) {
-                // Stop existing events, let the app take over with it's own config.
-                mEdgeEventsConnection.stopEdgeEvents();
-            }
-            mEdgeEventsConnection.runEdgeEvents();
-            Log.i(TAG, "EdgeEventsConnection is now started.");
-        } else {
-            Log.i(TAG, "EdgeEventsConnection is already running. Stop, before starting a new one.");
         }
 
+        // Start, if not already, the edgeEvents connection. It also starts any deferred events.
+        // Reconnecting via FindCloudlet, will also call startEdgeEvents.
+        if (mEdgeEventsConnection.isShutdown()) {
+            try {
+                mEdgeEventsConnection.open(dmeHost, dmePort, network, edgeEventsConfig);
+            } catch (DmeDnsException e) {
+                Log.e(TAG, "Cannot start edge events. Reason: " + e.getLocalizedMessage());
+                e.printStackTrace();
+            }
+            Log.i(TAG, "EdgeEventsConnection is now started.");
+        } else {
+            try {
+                Log.i(TAG, "EdgeEventsConnection is already running. Restarting.");
+                mEdgeEventsConnection.reconnect(dmeHost, dmePort, network, edgeEventsConfig);
+            } catch (DmeDnsException e) {
+                Log.e(TAG, "Failed to restart connection. DME Host name not found: " + dmeHost);
+                e.printStackTrace();
+            }
+        }
         return true;
     }
 
@@ -427,17 +451,12 @@ public class MatchingEngine {
             if (isShutdown()) {
                 return false;
             }
-            if (mEdgeEventsConnection == null) {
-                mEdgeEventsConnection = getEdgeEventsConnection();
-                if (mEdgeEventsConnection != null) {
-                    return true;
-                }
+
+            if (mEdgeEventsConnection.isShutdown()) {
+                mEdgeEventsConnection.open();
+            } else {
+                mEdgeEventsConnection.reconnect();
             }
-            // Same reconnect:
-            mEdgeEventsConnection.stopEdgeEvents();
-            mEdgeEventsConnection.reconnect();
-            mEdgeEventsConnection.awaitOpen();
-            mEdgeEventsConnection.runEdgeEvents();
             return true;
         } catch (DmeDnsException dde) {
             Log.e(TAG, "Background restart failed. Check DME DNS mapping." + dde.getMessage());
@@ -475,12 +494,11 @@ public class MatchingEngine {
     synchronized public boolean stopEdgeEvents() {
         warnIfUIThread();
         mAppInitiatedRunEdgeEvents = false;
-        if (mEdgeEventsConnection == null || mEdgeEventsConnection.isShutdown()) {
+        if (mEdgeEventsConnection.isShutdown()) {
             Log.i(TAG, "EdgeEventsConnection is already stopped.");
             return false;
         }
-        mEdgeEventsConnection.close();
-        mEdgeEventsConnection = null;
+        mEdgeEventsConnection.stopEdgeEvents();
         return true;
     }
 
@@ -521,54 +539,7 @@ public class MatchingEngine {
         return true;
     }
 
-    /*!
-     * Do not use in production.
-     *
-     * Gets or re-establishes a connection to the DME, and returns an EdgeEventsConnection singleton.
-     *
-     * \param dmeHost
-     * \param port
-     * \param network
-     * \param edgeEventsConfig This is a required configuration for edgeEvents.
-     * \return a connected EdgeEventsConnection instance
-     * \throws DmeDnsException
-     * \ingroup functions_dmeapis
-     */
-    synchronized EdgeEventsConnection getEdgeEventsConnection(String dmeHost,
-                                                              int dmePort,
-                                                              Network network,
-                                                              EdgeEventsConfig edgeEventsConfig)
-            throws DmeDnsException {
-        if (isShutdown()) {
-            Log.e(TAG, "MatchingEngine has been closed.");
-            return null;
-        }
-        if (!mEnableEdgeEvents) {
-            Log.d(TAG, "EdgeEvents has been disabled for this MatchingEngine. Enable to receive EdgeEvents states for your app.");
-            return null;
-        }
 
-        if (edgeEventsConfig == null) {
-            throw new IllegalArgumentException("EdgeEventsConfig is required to get an EdgeEventsConnection. You can create a default one with MatchingEngine createDefaultEdgeEventsConfig()");
-        }
-
-        // Clean:
-        if (mEdgeEventsConnection != null && !mEdgeEventsConnection.isShutdown()) {
-            if (edgeEventsConfig != null) {
-                mEdgeEventsConfig = edgeEventsConfig; // For future use, existing connection will keep config.
-            }
-            return mEdgeEventsConnection;
-        }
-
-        // Open:
-        if (dmeHost == null || dmePort == 0) {
-            mEdgeEventsConnection = new EdgeEventsConnection(this, edgeEventsConfig);
-        } else {
-            mEdgeEventsConnection = new EdgeEventsConnection(this, dmeHost, dmePort, network, edgeEventsConfig);
-        }
-        mEdgeEventsConnection.awaitOpen();
-        return mEdgeEventsConnection;
-    }
 
     /*!
      * Returns an EdgeEventsConnection singleton to call edge events util functions.
@@ -585,7 +556,7 @@ public class MatchingEngine {
         }, threadpool);
     }
 
-    public synchronized EdgeEventsConnection getEdgeEventsConnection() {
+    synchronized public EdgeEventsConnection getEdgeEventsConnection() {
         warnIfUIThread();
         if (isShutdown()) {
             Log.e(TAG, "MatchingEngine has been closed.");
@@ -593,20 +564,10 @@ public class MatchingEngine {
         }
         if (mEnableEdgeEvents == false)
         {
-            Log.e(TAG, "EdgeEvents has been disabled.");
+            Log.w(TAG, "EdgeEvents has been disabled.");
             return null;
         }
-        if (mEdgeEventsConnection == null || mEdgeEventsConnection.isShutdown())
-        {
-            Log.w(TAG, "There is no current active EdgeEventsConnection, or is swapping edgeEvents connections if already started.");
-            try {
-                mEdgeEventsConnection = new EdgeEventsConnection(this, mEdgeEventsConfig);
-                mEdgeEventsConnection.awaitOpen();
-                return mEdgeEventsConnection;
-            } catch (DmeDnsException dde) {
-                throw new CompletionException(dde);
-            }
-        }
+
         return mEdgeEventsConnection;
     }
 


### PR DESCRIPTION
Location and latency tasks potentially live outside the lifecycle of the appContext, or MatchingEngine context if they keep a reference around, not garbage collecting even after close(). This is true even if the SDK "controls" it. Timers are run by the OS underneath.

1) Cancel timers earlier, ASAP.
2) If a thread context is already in flight inside, check atomic "shutdown" variables, and stop any more calls right at the public interfaces.

If the app is trying to hold context of a closed() MatchingEngine and not garbage collect, that's mostly an app bug, but we can guard with the above changes.

This change creates "clean" test cases without random null pointers or oddball GRPC states due to Threaded tasks in flight before or during shutdown() was executed.

The in-flight task's only job is to exit ASAP once it sees the engine actually closed itself during execution. The scheduler at that point, can fully cancel() the scheduled task.