### PR TITLE
EDGECLOUD-5340: Disable EdgeEvents in MEL Mode

### DIFF
--- a/EmptyMatchEngineApp/app/build.gradle
+++ b/EmptyMatchEngineApp/app/build.gradle
@@ -6,8 +6,8 @@ android {
         applicationId "com.mobiledgex.sdkdemo"
         minSdkVersion 24
         targetSdkVersion 29
-        versionCode 22
-        versionName "2.6.22"
+        versionCode 23
+        versionName "2.6.23"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
@@ -39,7 +39,7 @@ dependencies {
     implementation 'com.google.guava:guava:29.0-android'
 
     // Use maven:
-    //implementation 'com.mobiledgex:matchingengine:2.6.22'
+    //implementation 'com.mobiledgex:matchingengine:2.6.23'
     //implementation 'com.mobiledgex:mel:1.0.11'
     // Dependencies of Matching Engine, if using Maven:
     implementation "io.grpc:grpc-stub:${grpcVersion}"

--- a/EmptyMatchEngineApp/matchingengine/build.gradle
+++ b/EmptyMatchEngineApp/matchingengine/build.gradle
@@ -21,8 +21,8 @@ android {
     defaultConfig {
         minSdkVersion 24
         targetSdkVersion 29
-        versionCode 22
-        versionName "2.6.22"
+        versionCode 23
+        versionName "2.6.23"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngine.java
+++ b/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngine.java
@@ -332,6 +332,11 @@ public class MatchingEngine {
         if (isShutdown()) {
             return false;
         }
+        if (MelMessaging.isMelEnabled()) {
+            Log.w(TAG, "MEL Mode is not compatible with EdgeEvents. Not starting EdgeEvents.");
+            return false;
+        }
+
         mAppInitiatedRunEdgeEvents = true;
         try {
             return startEdgeEvents(null, 0, null, edgeEventsConfig);
@@ -349,6 +354,10 @@ public class MatchingEngine {
             edgeEventsConfig.locationUpdateConfig = null;
         }
         if (isShutdown()) {
+            return false;
+        }
+        if (MelMessaging.isMelEnabled()) {
+            Log.w(TAG, "MEL Mode is not compatible with EdgeEvents. Not starting EdgeEvents.");
             return false;
         }
 


### PR DESCRIPTION
Pretty simple tweak: It makes explicit MEL mode is incompatible with the other AppInst selector, EdgeEvents that is under control of the SDK and application for reaction (like transfer app states).

App should not be setting WiFi mode in mel. Not this is not a new statement: MEC has no idea the app used wifi.dme otherwise, and always uses MCC-MNC. 