### PR TITLE
Device info send carrier name

### DIFF
--- a/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngine.java
+++ b/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/MatchingEngine.java
@@ -875,9 +875,9 @@ public class MatchingEngine {
             deviceInfoBuilder.setDataNetworkType(dataNetworkType.name());
         }
 
-        String mccmnc = getMccMnc(mContext);
-        if (mccmnc != null) {
-            deviceInfoBuilder.setCarrierName(mccmnc);
+        String carrierName = getCarrierName(mContext);
+        if (carrierName != null) {
+            deviceInfoBuilder.setCarrierName(carrierName);
         }
         deviceInfoBuilder.setSignalStrength(DeviceInfoUtil.getSignalStrengthLevel(mContext));
         return deviceInfoBuilder.build();


### PR DESCRIPTION
Preview for now. It even matches the setter now. :) We should send both in a new bug, but this at least makes it consistent for wifi-only mode ("").

Will need to see if we need to save the FindCloudlet carrierName for usage here, which will be another change. These overrides are sort of abnormal to begin with, as it will prevent roaming during edge events, so that change can wait a bit for consideration.

C# SDK: This interface is implemented inside the Unity SDK. Should recheck this bug there too (getCarrierName, not getMccMnc).