### PR TITLE
EDGECLOUD-5607: Use Any TCP port if internal port is 0.

### DIFF
--- a/EmptyMatchEngineApp/app/build.gradle
+++ b/EmptyMatchEngineApp/app/build.gradle
@@ -6,8 +6,8 @@ android {
         applicationId "com.mobiledgex.sdkdemo"
         minSdkVersion 24
         targetSdkVersion 29
-        versionCode 24
-        versionName "3.0"
+        versionCode 25
+        versionName "3.0.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/EmptyMatchEngineApp/app/src/main/java/com/mobiledgex/sdkdemo/MainActivity.java
+++ b/EmptyMatchEngineApp/app/src/main/java/com/mobiledgex/sdkdemo/MainActivity.java
@@ -295,7 +295,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
             backgroundEdgeEventsConfig.latencyTestType = NetTest.TestType.CONNECT;
 
             // This is the internal port, that has not been remapped to a public port for a particular appInst.
-            backgroundEdgeEventsConfig.latencyInternalPort = 3765; // 0 will favor the first TCP port if found for connect test.
+            backgroundEdgeEventsConfig.latencyInternalPort = 0; // 3765; // 0 will favor the first TCP port if found for connect test.
             // Latency config. There is also a very similar location update config.
             backgroundEdgeEventsConfig.latencyUpdateConfig.maxNumberOfUpdates = 0; // Default is 0, which means test forever.
             backgroundEdgeEventsConfig.latencyUpdateConfig.updateIntervalSeconds = 7; // The default is 30.
@@ -589,8 +589,10 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
     public void onPause() {
         super.onPause();
         stopLocationUpdates();
-        me.close();
-        me = null;
+        if (me != null) {
+            me.close();
+            me = null;
+        }
     }
 
     @Override

--- a/EmptyMatchEngineApp/matchingengine/build.gradle
+++ b/EmptyMatchEngineApp/matchingengine/build.gradle
@@ -21,8 +21,8 @@ android {
     defaultConfig {
         minSdkVersion 24
         targetSdkVersion 29
-        versionCode 24
-        versionName "3.0"
+        versionCode 25
+        versionName "3.0.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/AppConnectionManager.java
+++ b/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/AppConnectionManager.java
@@ -223,7 +223,7 @@ public class AppConnectionManager {
                     return publicPort;
                 }
             } catch (InvalidPortException e) {
-                Log.d(TAG, "Internal Port [" + internalPort + "] Not found in AppPort, continuing to next port...");
+                Log.d(TAG, "Internal Port [" + internalPort + "] Not found in this AppPort, continuing to next port to find public port...");
                 continue;
             }
         }
@@ -232,20 +232,27 @@ public class AppConnectionManager {
 
     public AppPort getAppPort(AppClient.FindCloudletReply findCloudletReply, int internalPort) {
         int publicPort = 0;
-        AppPort aPort = null;
-        // Get's the appPort with the internal port:
+        // Gets the appPort with the internal port:
         for (Appcommon.AppPort p : findCloudletReply.getPortsList()) {
             try {
+                // Ranged port.
                 publicPort = getPort(p, internalPort);
                 if (publicPort != 0) {
-                    aPort = p;
+                    if (internalPort == 0 && p.getProto() == LProto.L_PROTO_TCP) { // Any TCP port is fine.
+                        Log.d(TAG, "Returning any TCP public port: " + publicPort);
+                        return p;
+                    }
+                    else {
+                        return p;
+                    }
                 }
             } catch (InvalidPortException e) {
                 Log.d(TAG, "Internal Port [" + internalPort + "] not found in this AppPort, continuing to next AppPort...");
                 continue;
             }
         }
-        return aPort;
+        // found nothing;
+        return null;
     }
 
     /*!

--- a/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/EdgeEventsConnection.java
+++ b/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/EdgeEventsConnection.java
@@ -1486,19 +1486,19 @@ public class EdgeEventsConnection {
                         return false;
                     }
 
-                    if (mEdgeEventsConfig.latencyInternalPort <= 0 || mEdgeEventsConfig.latencyTestType == NetTest.TestType.PING) {
+                    int internalPort = mEdgeEventsConfig.latencyInternalPort <= 0 ? 0 : mEdgeEventsConfig.latencyInternalPort;
+                    if (mEdgeEventsConfig.latencyTestType == NetTest.TestType.PING) {
                         me.getEdgeEventsConnection().testPingAndPostLatencyUpdate(getLocation());
                         return false;
                     }
 
-                    // have (internal) port defined, use it.
-                    int publicPort = me.getAppConnectionManager().getPublicPort(lastConnectionDetails.currentCloudlet, mEdgeEventsConfig.latencyInternalPort);
+                    int publicPort = me.getAppConnectionManager().getPublicPort(lastConnectionDetails.currentCloudlet, internalPort);
                     if (publicPort == 0) {
-                        Log.i(TAG, "Your expected server (or port) doesn't seem to be here!");
-                        return false;
+                        Log.i(TAG, "Your expected server (or port) doesn't seem to be here! Internal Port: " + internalPort);
                     }
+
                     // Test with default network in use:
-                    Appcommon.AppPort appPort = me.getAppConnectionManager().getAppPort(lastConnectionDetails.currentCloudlet, mEdgeEventsConfig.latencyInternalPort);
+                    Appcommon.AppPort appPort = me.getAppConnectionManager().getAppPort(lastConnectionDetails.currentCloudlet, internalPort);
                     if (appPort == null) {
                         postErrorToEventHandler(EdgeEventsError.portDoesNotExist);
                         return false;


### PR DESCRIPTION
Fix Latency test if Ping (no port needed), and respect config if CONNECT and choose a port if unspecified. Basically, tweak the meaning of a 0 or negative port to allow CONNECT to happen.