### PR TITLE
PerformanceMode FindCloudlet: Internal error state - use better enum error to post to app.

### DIFF
--- a/EmptyMatchEngineApp/app/build.gradle
+++ b/EmptyMatchEngineApp/app/build.gradle
@@ -7,7 +7,7 @@ android {
         minSdkVersion 24
         targetSdkVersion 29
         versionCode 25
-        versionName "3.0.1"
+        versionName "3.0.3"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/EmptyMatchEngineApp/matchingengine/build.gradle
+++ b/EmptyMatchEngineApp/matchingengine/build.gradle
@@ -22,7 +22,7 @@ android {
         minSdkVersion 24
         targetSdkVersion 29
         versionCode 25
-        versionName "3.0.1"
+        versionName "3.0.3"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/EdgeEventsConnection.java
+++ b/EmptyMatchEngineApp/matchingengine/src/main/java/com/mobiledgex/matchingengine/EdgeEventsConnection.java
@@ -316,7 +316,7 @@ public class EdgeEventsConnection {
     synchronized private void postToFindCloudletEventHandler(FindCloudletEvent findCloudletEvent) {
         Log.d(TAG, "postToFindCloudletEventHandler");
         if (!validateFindCloudlet(findCloudletEvent.newCloudlet)) {
-            postErrorToEventHandler(EdgeEventsError.missingEdgeEventsConfig);
+            postErrorToEventHandler(EdgeEventsError.eventTriggeredButFindCloudletError);
             return;
         }
 


### PR DESCRIPTION
to be clear, this isn't supposed to ever happen with edgeEvents (missing edgeeventscookie, or even NOT_FOUND after finding something). It may complain to Log.e if a future change breaks something, as well as post to the app (for test cases to catch that unexpected error).