### PR TITLE
EDGECLOUD Add Apache 2.0 license to matchingengine POM file.

### DIFF
--- a/EmptyMatchEngineApp/app/build.gradle
+++ b/EmptyMatchEngineApp/app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.application'
+apply plugin: "com.google.android.gms.oss-licenses-plugin"
 
 android {
     compileSdkVersion 31
@@ -6,8 +7,8 @@ android {
         applicationId "com.mobiledgex.sdkdemo"
         minSdkVersion 24
         targetSdkVersion 31
-        versionCode 26
-        versionName '3.0.6'
+        versionCode 27
+        versionName '3.0.8'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
@@ -38,7 +39,7 @@ dependencies {
     implementation 'com.google.guava:guava:29.0-android'
 
     // Use maven:
-    //implementation 'com.mobiledgex:matchingengine:3.0'
+    //implementation 'com.mobiledgex:matchingengine:3.0.8'
     // Dependencies of Matching Engine, if using Maven:
     implementation "io.grpc:grpc-stub:${grpcVersion}"
 
@@ -47,5 +48,6 @@ dependencies {
     implementation "io.grpc:grpc-protobuf-lite:${grpcVersion}"
 
     // For Google Location Services.
-    implementation 'com.google.android.gms:play-services-location:19.0.0'
+    implementation 'com.google.android.gms:play-services-location:19.0.1'
+    implementation("com.google.android.gms:play-services-oss-licenses:17.0.0")
 }

--- a/EmptyMatchEngineApp/build.gradle
+++ b/EmptyMatchEngineApp/build.gradle
@@ -31,6 +31,7 @@ buildscript {
 
         classpath "org.ysb33r.gradle:doxygen-gradle-plugin:0.7.0"
 
+        classpath("com.google.android.gms:oss-licenses-plugin:0.10.4")
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/EmptyMatchEngineApp/matchingengine/build.gradle
+++ b/EmptyMatchEngineApp/matchingengine/build.gradle
@@ -21,8 +21,8 @@ android {
     defaultConfig {
         minSdkVersion 24
         targetSdkVersion 31
-        versionCode 26
-        versionName "3.0.7"
+        versionCode 27
+        versionName "3.0.8"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -90,7 +90,6 @@ protobuf {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-
     implementation 'androidx.appcompat:appcompat:1.4.0'
     implementation 'com.google.android.material:material:1.4.0'
 
@@ -119,8 +118,28 @@ publishing {
             groupId = "com.mobiledgex"
             artifactId = project.getName()
             version = android.defaultConfig.versionName
+
             // Tell maven to prepare the generated "*.aar" file for publishing
             artifact("$buildDir/outputs/aar/${project.getName()}-release.aar")
+
+            pom.withXml {
+                asNode().with {
+                    appendNode('name', 'matchingengine')
+                    appendNode('description', 'MobiledgeX MatchingEngine library to access your global edge cloud application resources')
+                    appendNode('url', 'https://github.com/mobiledgex/edge-cloud-sdk-android')
+                    appendNode('licenses').with {
+                        appendNode('license').with {
+                            appendNode('name', 'The Apache Software License, Version 2.0')
+                            appendNode('url', 'https://www.apache.org/licenses/LICENSE-2.0.txt')
+                        }
+                    }
+                    appendNode('developers').with {
+                        appendNode('developer').with {
+                            appendNode('name', 'MobiledgeX, Inc.')
+                        }
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Apache 2.0 License to POM, using pom.withXml function.

per this application side plugin documentation that will use the generated output:
https://developers.google.com/android/guides/opensource

I was attempting to do this via including a copy of our LICENSE.txt into the META-INF/LICENSE.txt of the actual AAR file, but I'm not sure how to do that with Artifactory's plugin. POM is semi standard, and the output happens to be the same for most.

However, there's not really any kind of standard for stating a license. The license is needed for automated license checkers, so this is a good start in any case.

It does not have our customized license file header this way, but better than blank for now.

Note: despite the incompleteness of the tool, googles OSS third party licenses plugin is the only one working for the moment.